### PR TITLE
Authorize GET requests with CORS

### DIFF
--- a/fn.go
+++ b/fn.go
@@ -13,6 +13,15 @@ var (
 )
 
 func IsItTheWinterBreakYet(w http.ResponseWriter, r *http.Request) {
+	if  r.Method == http.MethodOptions {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "GET")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+		w.Header().Set("Access-Control-Allow-Max-Age", "3600")
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	w.Header().Set("Access-Control-Allow-Origin", "*")
 	fmt.Fprint(w, "{\"is_winter_break_yet\":\""+strconv.FormatBool(isWinterBreakYet())+"\", \"winter_break\": {\"start_time\":\""+startTime.Format(time.RFC3339)+"\", \"end_time\":\""+endTime.Format(time.RFC3339)+"\"}}")
 }
 


### PR DESCRIPTION
Authorize GET requests with CORS.

CORS triggers an OPTIONS prerequests which this code will intercept and fill the headers' values with the authorization of GET request from all origins.

The second addition (outside the if) will validate the GET request regardless of the origin

Closes #5  